### PR TITLE
Make Homenote settings non public

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joplin-plugin-home-note",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "dist": "webpack --env joplin-plugin-config=buildMain && webpack --env joplin-plugin-config=buildExtraScripts && webpack --env joplin-plugin-config=createArchive",
     "prepare": "npm run dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import joplin from "api";
-import { MenuItemLocation, ToolbarButtonLocation } from "api/types";
+import { MenuItemLocation, SettingItemType, ToolbarButtonLocation } from "api/types";
 
 joplin.plugins.register({
 	onStart: async function () {
@@ -7,9 +7,8 @@ joplin.plugins.register({
 		await joplin.settings.registerSettings({
 			homeNoteId: {
 				value: '',
-				type: 2, // String type
-				section: 'myPluginSection',
-				public: true,
+				type: SettingItemType.String, 
+				public: false,
 				label: 'Home Note ID',
 			},
 		});

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 1,
 	"id": "com.lki.homenote",
 	"app_min_version": "1.7",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"name": "Home Note",
 	"description": "Plugin to open a choosen note each time joplin starts. It is like homepages on browsers.",
 	"author": "Adarsh Singh(lki)",


### PR DESCRIPTION
Since setting homenote id is not something the user would be doing manually, it's better if this is accessed only programmatically.
Fixes #22